### PR TITLE
feat(authentication): add JWT authentication via cookies

### DIFF
--- a/authentication/authentication.py
+++ b/authentication/authentication.py
@@ -1,0 +1,11 @@
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework.exceptions import AuthenticationFailed
+
+class CookieJWTAuthentication(JWTAuthentication):
+    def authenticate(self, request):
+        access_token = request.COOKIES.get('access_token')
+        if access_token is None:
+            return None  
+
+        validated_token = self.get_validated_token(access_token)
+        return self.get_user(validated_token), validated_token


### PR DESCRIPTION
This PR enhances the authentication app by overriding the default JWT authentication to enable token storage via secure HTTP-only cookies. Access and refresh tokens are now stored in cookies to improve security and client management.
Additionally, the email verification view was updated to store tokens in cookies upon code confirmation.