### PR TITLE
fix(password_reset_services): corrigir base_url adicionando URL do front-end

### DIFF
--- a/authentication/services/password_reset_services.py
+++ b/authentication/services/password_reset_services.py
@@ -3,7 +3,7 @@ from decouple import config
 class PasswordResetService:
 
     def generate_reset_link(self, token, email_encoded):
-        base_url = config("BASE_URL")
+        base_url = 'http://rotas-da-ibiapaba-frontend.vercel.app/reset_password'
         return f"{base_url}?token={token}&email={email_encoded}"
 
     def validate_passwords(self, password1, password2):


### PR DESCRIPTION
- Corrige a base_url usada para gerar o link de reset de senha.
- A URL agora aponta para o front-end (http://rotas-da-ibiapaba-frontend.vercel.app/reset_password) em vez de rotas internas da API.
- Garante que o usuário receba um link correto para redefinir a senha na interface do cliente.
